### PR TITLE
Prod docker compose

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -38,8 +38,6 @@ services:
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}
     ports:
       - "3306:3306"
-    networks:
-      - spring-net
     volumes:
       - mysql-data:/bitnami/mysql/data
       # - ./mysql-init-scripts:/docker-entrypoint-initdb.d
@@ -71,12 +69,6 @@ services:
     depends_on:
       mysql-db:
         condition: service_healthy
-    networks:
-      - spring-net
-
-networks:
-  spring-net:
-    driver: bridge
 
 volumes:
   letsencrypt:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,84 @@
+services:
+  watchtower:
+    image: containrrr/watchtower
+    command:
+      - "--label-enable"
+      - "--interval"
+      - "30"
+      - "--rolling-restart"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+  reverse-proxy:
+    image: traefik:v3.1
+    command:
+      - "--providers.docker"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entryPoints.websecure.address=:443"
+      - "--certificatesresolvers.myresolver.acme.tlschallenge=true"
+      - "--certificatesresolvers.myresolver.acme.email=commercify@zenfulcode.com"
+      - "--certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.web.http.redirections.entrypoint.to=websecure"
+      - "--entrypoints.web.http.redirections.entrypoint.scheme=https"
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - letsencrypt:/letsencrypt
+      - /var/run/docker.sock:/var/run/docker.sock
+  mysql-db:
+    image: docker.io/bitnami/mysql:8.4
+    container_name: mysql-db
+    env_file: .env
+    environment:
+      ALLOW_EMPTY_PASSWORD: "no"
+      MYSQL_DATABASE: commercifydb
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+    ports:
+      - "3306:3306"
+    networks:
+      - spring-net
+    volumes:
+      - mysql-data:/bitnami/mysql/data
+      # - ./mysql-init-scripts:/docker-entrypoint-initdb.d
+    healthcheck:
+      test: ["CMD", "/opt/bitnami/scripts/mysql/healthcheck.sh"]
+      interval: 15s
+      timeout: 5s
+      retries: 6
+
+  commercify:
+    image: ghcr.io/zenfulcode/commercify:main
+    env_file: .env
+    container_name: commercify-api
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.commercify.rule=Host(`zenfulcode.com`)"
+      - "traefik.http.routers.commercify.entrypoints=websecure"
+      - "traefik.http.routers.commercify.tls.certresolver=myresolver"
+      - "com.centurylinklabs.watchtower.enable=true"
+    ports:
+      - "8080:8080"
+    environment:
+      - SPRING_PROFILES_ACTIVE=docker
+      - SPRING_DATASOURCE_URL=${SPRING_DATASOURCE_URL}
+      - SPRING_DATASOURCE_USERNAME=${SPRING_DATASOURCE_USERNAME}
+      - SPRING_DATASOURCE_PASSWORD=${SPRING_DATASOURCE_PASSWORD}
+      - STRIPE_TEST_SECRET=${STRIPE_TEST_SECRET}
+      - JWT_SECRET_KEY=${JWT_SECRET_KEY}
+    depends_on:
+      mysql-db:
+        condition: service_healthy
+    networks:
+      - spring-net
+
+networks:
+  spring-net:
+    driver: bridge
+
+volumes:
+  letsencrypt:
+  mysql-data:
+    driver: local


### PR DESCRIPTION
This pull request introduces a new `docker-compose.prod.yml` file to set up the production environment with Docker Compose. The configuration includes services for automatic updates, reverse proxy, MySQL database, and the main application.

### New Services Added:

* **Watchtower**: Added for automatic updates of Docker containers. (`docker-compose.prod.yml`)
* **Reverse Proxy**: Configured using Traefik to handle HTTPS and HTTP redirections. (`docker-compose.prod.yml`)
* **MySQL Database**: Set up MySQL database with environment variables for credentials and health checks. (`docker-compose.prod.yml`)
* **Commercify API**: Configured the main application service with environment variables, labels for Traefik routing, and dependencies on the MySQL service. (`docker-compose.prod.yml`)

### Volumes:

* **Persistent Storage**: Defined volumes for Let's Encrypt data and MySQL data to ensure data persistence across container restarts. (`docker-compose.prod.yml`)