### PR TITLE
Release

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,76 @@
+services:
+  watchtower:
+    image: containrrr/watchtower
+    command:
+      - "--label-enable"
+      - "--interval"
+      - "30"
+      - "--rolling-restart"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+  reverse-proxy:
+    image: traefik:v3.1
+    command:
+      - "--providers.docker"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entryPoints.websecure.address=:443"
+      - "--certificatesresolvers.myresolver.acme.tlschallenge=true"
+      - "--certificatesresolvers.myresolver.acme.email=commercify@zenfulcode.com"
+      - "--certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.web.http.redirections.entrypoint.to=websecure"
+      - "--entrypoints.web.http.redirections.entrypoint.scheme=https"
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - letsencrypt:/letsencrypt
+      - /var/run/docker.sock:/var/run/docker.sock
+  mysql-db:
+    image: docker.io/bitnami/mysql:8.4
+    container_name: mysql-db
+    env_file: .env
+    environment:
+      ALLOW_EMPTY_PASSWORD: "no"
+      MYSQL_DATABASE: commercifydb
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql-data:/bitnami/mysql/data
+      # - ./mysql-init-scripts:/docker-entrypoint-initdb.d
+    healthcheck:
+      test: ["CMD", "/opt/bitnami/scripts/mysql/healthcheck.sh"]
+      interval: 15s
+      timeout: 5s
+      retries: 6
+
+  commercify:
+    image: ghcr.io/zenfulcode/commercify:main
+    env_file: .env
+    container_name: commercify-api
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.commercify.rule=Host(`zenfulcode.com`)"
+      - "traefik.http.routers.commercify.entrypoints=websecure"
+      - "traefik.http.routers.commercify.tls.certresolver=myresolver"
+      - "com.centurylinklabs.watchtower.enable=true"
+    ports:
+      - "8080:8080"
+    environment:
+      - SPRING_PROFILES_ACTIVE=docker
+      - SPRING_DATASOURCE_URL=${SPRING_DATASOURCE_URL}
+      - SPRING_DATASOURCE_USERNAME=${SPRING_DATASOURCE_USERNAME}
+      - SPRING_DATASOURCE_PASSWORD=${SPRING_DATASOURCE_PASSWORD}
+      - STRIPE_TEST_SECRET=${STRIPE_TEST_SECRET}
+      - JWT_SECRET_KEY=${JWT_SECRET_KEY}
+    depends_on:
+      mysql-db:
+        condition: service_healthy
+
+volumes:
+  letsencrypt:
+  mysql-data:
+    driver: local

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -22,6 +22,7 @@ services:
       - "--entrypoints.web.http.redirections.entrypoint.scheme=https"
     ports:
       - "80:80"
+      - "8080:8080"
       - "443:443"
     volumes:
       - letsencrypt:/letsencrypt
@@ -36,8 +37,8 @@ services:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
       MYSQL_USER: ${MYSQL_USER}
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}
-    ports:
-      - "3306:3306"
+    expose:
+      - 3306
     volumes:
       - mysql-data:/bitnami/mysql/data
       # - ./mysql-init-scripts:/docker-entrypoint-initdb.d
@@ -47,18 +48,32 @@ services:
       timeout: 5s
       retries: 6
 
-  commercify:
-    image: ghcr.io/zenfulcode/commercify:main
+  commercifyweb:
+    image: ghcr.io/zenfulcode/commercifyweb:dev
     env_file: .env
-    container_name: commercify-api
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.commercify.rule=Host(`zenfulcode.com`)"
+      - "traefik.http.routers.commercify.rule=Host(`commercify.app`)"
       - "traefik.http.routers.commercify.entrypoints=websecure"
       - "traefik.http.routers.commercify.tls.certresolver=myresolver"
       - "com.centurylinklabs.watchtower.enable=true"
-    ports:
-      - "8080:8080"
+    environment:
+      - NEXT_PUBLIC_COMMERCIFY_API_URL=https://commercify.app:6091/api/v1
+    # deploy:
+    #   mode: replicated
+    #   replicas: 3
+    depends_on:
+      - commercify
+
+  commercify:
+    image: ghcr.io/zenfulcode/commercify:dev
+    env_file: .env
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.commercify-api.rule=Host(`api.commercify.app`)"
+      - "traefik.http.routers.commercify-api.entrypoints=websecure"
+      - "traefik.http.routers.commercify-api.tls.certresolver=myresolver"
+      - "com.centurylinklabs.watchtower.enable=true"
     environment:
       - SPRING_PROFILES_ACTIVE=docker
       - SPRING_DATASOURCE_URL=${SPRING_DATASOURCE_URL}
@@ -66,6 +81,11 @@ services:
       - SPRING_DATASOURCE_PASSWORD=${SPRING_DATASOURCE_PASSWORD}
       - STRIPE_TEST_SECRET=${STRIPE_TEST_SECRET}
       - JWT_SECRET_KEY=${JWT_SECRET_KEY}
+    expose:
+      - 6091
+    # deploy:
+    #   mode: replicated
+    #   replicas: 3
     depends_on:
       mysql-db:
         condition: service_healthy


### PR DESCRIPTION
This pull request adds a new `docker-compose.prod.yml` configuration file to set up services for production. The most important changes include the addition of Watchtower for automated Docker container updates, Traefik as a reverse proxy, a MySQL database, and the Commercify web and API services.

New services added:

* [`docker-compose.prod.yml`](diffhunk://#diff-4563fbe997bbf18c3b38ad79c596c57c3ad88361f1dccb8c4f39b429382c06d3R1-R96): Added Watchtower service to handle automated Docker container updates.
* [`docker-compose.prod.yml`](diffhunk://#diff-4563fbe997bbf18c3b38ad79c596c57c3ad88361f1dccb8c4f39b429382c06d3R1-R96): Added Traefik reverse proxy configuration to manage HTTP and HTTPS traffic.
* [`docker-compose.prod.yml`](diffhunk://#diff-4563fbe997bbf18c3b38ad79c596c57c3ad88361f1dccb8c4f39b429382c06d3R1-R96): Added MySQL database service with environment variables for secure configuration.

Commercify services:

* [`docker-compose.prod.yml`](diffhunk://#diff-4563fbe997bbf18c3b38ad79c596c57c3ad88361f1dccb8c4f39b429382c06d3R1-R96): Added `commercifyweb` service for the Commercify web application, including Traefik labels for routing.
* [`docker-compose.prod.yml`](diffhunk://#diff-4563fbe997bbf18c3b38ad79c596c57c3ad88361f1dccb8c4f39b429382c06d3R1-R96): Added `commercify` service for the Commercify API, with environment variables and dependencies.