### PR TITLE
fix: build error

### DIFF
--- a/src/app/(client)/products/[id]/page.tsx
+++ b/src/app/(client)/products/[id]/page.tsx
@@ -8,7 +8,7 @@ interface ProductPageProps {
   }
   
   export default async function ProductPage({ params }: ProductPageProps) {
-    const product = await productApi.getProductById(parseInt(params.id));
+    const product = await productApi.getProductById(params.id);
     
     return <ProductDetails product={product} />;
   }


### PR DESCRIPTION
This pull request includes a minor change to the `ProductPage` function in the `src/app/(client)/products/[id]/page.tsx` file. The change simplifies the call to `productApi.getProductById` by directly passing the `params.id` without converting it to an integer.

* `src/app/(client)/products/[id]/page.tsx`: Modified the `ProductPage` function to pass `params.id` directly to `productApi.getProductById` without parsing it as an integer. ([src/app/(client)/products/[id]/page.tsxL11-R11](diffhunk://#diff-fac0ffa1a23fcac2355e200c12b1551c89bded8aff2d89dbd341af4ac9d7e3caL11-R11))